### PR TITLE
UX Adjustments

### DIFF
--- a/code/modules/client/client_procs.dm
+++ b/code/modules/client/client_procs.dm
@@ -444,7 +444,6 @@ client/proc/MayRespawn()
 
 /client/New()
 	..()
-	fullscreen()
 
 /client/verb/fullscreen_toggle()
 	set name = ".fullscreen_toggle"

--- a/code/modules/client/preferences.dm
+++ b/code/modules/client/preferences.dm
@@ -96,7 +96,7 @@ datum/preferences
 	dat += "<br>"
 	dat += player_setup.content(user)
 	dat += "</html></body>"
-	user <<browse(dat,"window=player_panel;size=600x600;can_close=0;can_resize=0;border=[is_bordered];titlebar=[is_bordered]")
+	user <<browse(dat,"window=player_panel;size=600x1000;can_close=0;can_resize=1;border=[is_bordered];titlebar=[is_bordered]")
 
 /datum/preferences/proc/process_link(mob/user, list/href_list)
 


### PR DESCRIPTION
Makes the game not fullscreen when starting, the option is there to toggle fullscreen still.

Makes the character creator window bigger to actually fit the character creator and also allows you to resize it..

WHY JANK? WHY??